### PR TITLE
Logical operator in p!cash command is wrong.

### DIFF
--- a/core/modules/rubine/cash.js
+++ b/core/modules/rubine/cash.js
@@ -54,7 +54,7 @@ function whoHas(who){
             case (r < 19999):
                 fam = vocab.c6
                 break;
-            case (r > 20000):
+            case (r >= 20000):
                 fam = vocab.c7
                 break;
         }


### PR DESCRIPTION
No text was appearing if target had exactly 20k.
Changed _>_ to _>=_.